### PR TITLE
Add bio pages

### DIFF
--- a/_pages/bio_emmah.md
+++ b/_pages/bio_emmah.md
@@ -1,14 +1,13 @@
 ---
 layout: single
-permalink: /group/emma_h
+permalink: /group/bios/emma_h
 title: "Emma Hobbs"
 toc: true
 toc_label: "Table of Contents"
 toc_icon: "book-reader"
 toc_sticky: true
+categories: Bio
 ---
-
-[Back to group members](/group)
 
 ## PhD Candidate
 

--- a/_pages/bio_emmah.md
+++ b/_pages/bio_emmah.md
@@ -1,12 +1,14 @@
 ---
 layout: single
-permalink: /group/EmmaH
+permalink: /group/emma_h
 title: "Emma Hobbs"
 toc: true
 toc_label: "Table of Contents"
 toc_icon: "book-reader"
 toc_sticky: true
 ---
+
+[Back to group members](/group)
 
 ## PhD Candidate
 

--- a/_pages/bio_emmah.md
+++ b/_pages/bio_emmah.md
@@ -1,0 +1,75 @@
+---
+layout: single
+permalink: /group/EmmaH
+title: "Emma Hobbs"
+toc: true
+toc_label: "Table of Contents"
+toc_icon: "book-reader"
+toc_sticky: true
+---
+
+## PhD Candidate
+
+Originally from England, Emma obtained a BSc (Hons) in Biochemistry from the University of Surrey. Her undergraduate degree included a 12-month industrial placement at GlaxoSmithKline’s Medical Research Centre (Hertfordshire, England), working within the Protein and Cellular Sciences department to design and generate candidate protein targets. Afterwards, in September 2019 Emma moved to St Andrews as a PhD student under the joint supervision of Dr Tracey Gloster (St Andrews), Dr Leighton Pritchard (Strathclyde) and Dr Sean Chapman (James Hutton).
+
+Emma's research focuses on data mining genomes to identify carbohydrate processing enzymes (CAZymes) for industrial exploitation in biofuel production. Specifically, Emma uses bioinformatics techniques to data-mine fungal genomes to identify potential plant cell-wall degrading enzymes. Emma is also exploring the evolution of CAZomes (all CAZymes within genomes of interest) in plant pathogenic and non-pathogenic bacteria. Understanding these repertoires of enzymes may influence the design of enzyme cocktails for industrial degradation of biomass, and elucidate the evolutionary arms race between plant host and pathogen.
+
+Emma's laboratory work includes: 
+- Using X-ray crystallography techniques to resolve the structural fold of novel plant cell-wall degrading enzymes
+- Design enzymatic assays to 
+- Use synthetic biology approaches to optimise CAZymes carbohydrate processing properties of potential use in biofuel production.
+
+In addition to her research, Emma has helped at several Software Carpentry workshops, hosted by the [Industrial Biotechology Innovation Centre (iBioIC)](https://www.ibioic.com/) and the [Software Sustainability Institute (SSI)](https://www.software.ac.uk/).
+
+Outside university, Emma frequently goes hiking in the Scottish wilderness, knits and plays video games.
+
+## Education/Academic Qualification
+
+**Doctorate of Philosophy (PhD)**  
+*University of St Andrews*  
+*University of Strathclyde*  
+*James Hutton Institute*  
+Sept 2019 - Dec 2023  
+
+**Bachelor of Science (Hons)**  
+*University of Surrey*  
+Sept 2015 - July 2019  
+
+## Supervisors
+
+- Tracey Gloster (University of St Andrews)
+- Leighton Pritchard (University of Strathclyde)
+- Sean Chapman (James Hutton Institute)
+
+## Research Output
+
+### Software
+
+Packages and repositories Emma has developed during her PhD:
+
+[**`cazy_webscraper`** - DOI: 10.5281/zenodo.6343936](https://hobnobmancer.github.io/cazy_webscraper/)  
+A tool to retrieve annotation, sequence, structure, genomic and taxonomic data from the [CAZy](www.cazy.org), [NCBI](https://www.ncbi.nlm.nih.gov/), [UniProt](https://www.uniprot.org/), [RSCB PDB](https://www.rcsb.org/) and [GTDB](https://gtdb.ecogenomic.org/) databases, and build a local SQLite3 CAZyme database.
+
+[**`pyrewton`** -  DOI: 10.5281/zenodo.3876218](https://hobnobmancer.github.io/pyrewton/)  
+A Python package for the independent and comprehensive evaluation of CAZyme classifications, and the creation of a comprehensive CAZome database (a database cataloguing proteomic data for all CAZymes within the genomes of species of interest).
+
+[**`cazomevolve`** -  DOI: 10.5281/zenodo.6614827](https://github.com/HobnobMancer/cazomevolve)  
+A Python package to explore the evolution of CAZomes, including the identification of networks of co-evolving CAZy families in genomes of interest.
+
+[**`saintBioutils`** - DOI: DOI: 10.5281/6541551](https://github.com/HobnobMancer/saintBioutils)  
+A collection of miscellenaious functions for bioinformatics tools and analyses
+
+### Publications
+
+Hobbs, Emma E. M.; Pritchard, Leighton; Chapman, Sean; Gloster, Tracey M. (2021): cazy_webscraper: For creating a local CAZyme database. figshare. Poster. [doi.org/10.6084/m9.figshare.14370860](https://doi.org/10.6084/m9.figshare.14370860.v7)
+
+Hobbs, Emma E. M.; Gloster, Tracey M.; Chapman, Sean; Pritchard, Leighton (2021): Comprehensive evaluation of CAZyme prediction tools in fungal and bacterial species. figshare. Poster. [doi.org/10.6084/m9.figshare.14370836](https://doi.org/10.6084/m9.figshare.14370836.v3)
+
+Hobbs, Emma E. M.; Pritchard, Leighton; Gloster, Tracey M.; Chapman, Sean (2021): cazy_webscraper - getting started. figshare. Poster. [doi.org/10.6084/m9.figshare.14370869](https://doi.org/10.6084/m9.figshare.14370869.v3)
+
+## Contact Information and Links
+
+**Email:** eemh1@st-andrews.ac.uk  
+[**GitHub**](https://github.com/HobnobMancer)  
+[**LinkedIn**](https://uk.linkedin.com/in/emma-eliza-hobbs)  
+[**Gloster Laboratory website**](https://synergy.st-andrews.ac.uk/gloster/)

--- a/_pages/bio_leighton.md
+++ b/_pages/bio_leighton.md
@@ -1,0 +1,29 @@
+---
+layout: single
+permalink: /group/bios/leighton
+title: "Leighton Pritchard"
+toc: true
+toc_label: "Table of Contents"
+toc_icon: "book-reader"
+toc_sticky: true
+categories: Bio
+---
+
+## Chancellor's Fellow (PI)
+
+Born in Salford, raised in Wigan, educated in Bolton, Leighton started out as a Chemist, earning a degree (BSc (Hons)) in Forensic and Analytical Chemistry from the University of Strathclyde, before realising that wasn't his calling and turning into a computational biologist for his final year project and PhD under the supervision of Mark Dufton, again at Strathclyde, investigating the evolution of snake venome toxins.
+
+After this, Leighton was a PDRA on two Systems Biology projects in Prof. Doug Kell's group in the Institute for Biological Sciences - as it was - at Aberystwyh (_ac mae e'n caru'r iaith Gymraeg, hyd yn oed yn awr_). He spent four years modelling yeast metabolism and rationally engineering proteins, before returning to Scotland to join the James Hutton Institute (until 2011 the Scottish Crop Research Institute) as a computational biologist. There he started working in host-pathogen interactions, microbial genomics, and diagnostics. In the meantime, he earned an Open University degree (BA (Hons)) in Mathematics.
+
+Leighton joined Strathclyde as a Chancellor's Fellow in 2019, just about having enough time to move his textbooks into the office, before the COVID pandemic hit.
+
+Other jobs have included: lots of heaving and hauling, largely in warehouses; product development chemist in the oil industry (where he learned just enough plumbing to get by); and body fluid analysis in a clinical biochemistry lab. 
+
+### Links
+
+You can find more up to date information at the links below:
+
+- [University of Strathclyde official page](https://www.strath.ac.uk/staff/pritchardleightondr/)
+- [University of Strathclyde Pure page](https://pureportal.strath.ac.uk/en/persons/leighton-pritchard)
+- [ORCID](https://orcid.org/0000-0002-8392-2822)
+- [Google Scholar](https://scholar.google.co.uk/citations?user=5QhdsWkAAAAJ&hl=en)

--- a/_pages/bios.md
+++ b/_pages/bios.md
@@ -1,0 +1,18 @@
+---
+layout: single
+permalink: /bios/
+title: "Group Bios"
+toc: true
+toc_label: "Table of Contents"
+toc_icon: "book-reader"
+toc_sticky: true
+---
+
+## Group Biographies
+
+{% for p in site.pages %}
+   {% if p.categories contains "Bio" %}
+- [{{ p.title }}]({{ p.url | absolute_url }})
+  - <small>{{ p.content | strip_html | truncatewords: 50 }}</small>
+   {% endif %}
+{% endfor %}

--- a/_pages/group.md
+++ b/_pages/group.md
@@ -13,10 +13,10 @@ toc_sticky: true
 ### Current Members
 
 - <img src="https://github.com/baileythegreen.png" alt="GitHub avatar for @baileythegreen" width="20"> Bailey Harrington (PDRA)
-- <img src="https://github.com/hobnobmancer.png" alt="GitHub avatar for @hobnobmancer" width="20"> [Emma Hobbs](/group/emma_h) (PhD, University of St Andrews)
+- <img src="https://github.com/hobnobmancer.png" alt="GitHub avatar for @hobnobmancer" width="20"> [Emma Hobbs](/group/bios/emma_h) (PhD, University of St Andrews)
 - <img src="https://github.com/kiepczi.png" alt="GitHub avatar for @kiepczi" width="20"> Angelika Kiepas (PhD)
 - <img src="https://github.com/JuliannaPiat.png" alt="GitHub avatar for @JuliannaPiat" width="20"> Julianna Piat (PhD, University of Oxford)
-- <img src="https://github.com/widdowquinn.png" alt="GitHub avatar for @widdowquinn" width="20"> Leighton Pritchard (Chancellor's Fellow, PI)
+- <img src="https://github.com/widdowquinn.png" alt="GitHub avatar for @widdowquinn" width="20"> [Leighton Pritchard](/group/bios/leighton) (Chancellor's Fellow, PI)
 
 - <img src="https://github.com/tharis.png" alt="GitHub avatar for @tharis" width="20"> Tom Harris (PhD, sup: Arnaud Javelle)
 - Tom Hender (PhD, sup: Nick Tucker)

--- a/_pages/group.md
+++ b/_pages/group.md
@@ -10,14 +10,15 @@ toc_sticky: true
 
 ## Group Members
 
-### Current
+### Current Members
 
-- Bailey Harrington (PDRA)
-- [Emma Hobbs](/group/emma_h) (PhD, University of St Andrews)
-- Angelika Kiepas (PhD)
-- Leighton Pritchard (Chancellor's Fellow, PI)
+- <img src="https://github.com/baileythegreen.png" alt="GitHub avatar for @baileythegreen" width="20"> Bailey Harrington (PDRA)
+- <img src="https://github.com/hobnobmancer.png" alt="GitHub avatar for @hobnobmancer" width="20"> [Emma Hobbs](/group/emma_h) (PhD, University of St Andrews)
+- <img src="https://github.com/kiepczi.png" alt="GitHub avatar for @kiepczi" width="20"> Angelika Kiepas (PhD)
+- <img src="https://github.com/JuliannaPiat.png" alt="GitHub avatar for @JuliannaPiat" width="20"> Julianna Piat (PhD, University of Oxford)
+- <img src="https://github.com/widdowquinn.png" alt="GitHub avatar for @widdowquinn" width="20"> Leighton Pritchard (Chancellor's Fellow, PI)
 
-- Tom Harris (PhD, sup: Arnaud Javelle)
+- <img src="https://github.com/tharis.png" alt="GitHub avatar for @tharis" width="20"> Tom Harris (PhD, sup: Arnaud Javelle)
 - Tom Hender (PhD, sup: Nick Tucker)
 
 - Yassmeen Ali (MSc, 2022)
@@ -25,11 +26,11 @@ toc_sticky: true
 - Areej Obaid (MSc, 2022)
 - David Teixeira (SfAM-funded Internship, 2022)
 
-### Former
+### Alumni
 
 - Rory McLeod (PhD, 2016-2020, University of Dundee)
 - Christelle Robert (PhD, 2006-2009, University of Dundee)
-- Nick Waters (PhD, 2016-2020, NUI Galway)
+- <img src="https://github.com/nickp60.png" alt="GitHub avatar for @nickp60" width="20"> Nick Waters (PhD, 2016-2020, NUI Galway)
 - Eirini Xemantilotou (PhD, 2015-2019, University of St Andrews)
 
 - Ramzi Alahmadi (MSc, 2021)

--- a/_pages/group.md
+++ b/_pages/group.md
@@ -13,7 +13,7 @@ toc_sticky: true
 ### Current
 
 - Bailey Harrington (PDRA)
-- Emma Hobbs (PhD, University of St Andrews)
+- [Emma Hobbs](/group/emma_h) (PhD, University of St Andrews)
 - Angelika Kiepas (PhD)
 - Leighton Pritchard (Chancellor's Fellow, PI)
 

--- a/_pages/group_bios.md
+++ b/_pages/group_bios.md
@@ -1,0 +1,18 @@
+---
+layout: single
+permalink: /group/bios/
+title: "Group Bios"
+toc: true
+toc_label: "Table of Contents"
+toc_icon: "book-reader"
+toc_sticky: true
+---
+
+## Group Biographies
+
+{% for p in site.pages %}
+   {% if p.categories contains "Bio" %}
+- [{{ p.title }}]({{ p.url | absolute_url }})
+  - <small>{{ p.content | strip_html | truncatewords: 50 }}</small>
+   {% endif %}
+{% endfor %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -12,7 +12,7 @@ feature_row:
   - image_path: /assets/fontawesome/svgs/solid/people-roof.svg
     alt: "group info"
     title: "Group Info"
-    excerpt: "About the group and resources for the research group."
+    excerpt: "Resources and bios for the research group."
     url: "./group"
     btn_class: "btn--primary"
     btn_label: "Group Info"

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -12,7 +12,7 @@ feature_row:
   - image_path: /assets/fontawesome/svgs/solid/people-roof.svg
     alt: "group info"
     title: "Group Info"
-    excerpt: "Resources for the research group."
+    excerpt: "About the group and resources for the research group."
     url: "./group"
     btn_class: "btn--primary"
     btn_label: "Group Info"


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Add first group member bio page

## Context

- Add first draft of bio page for Emma
- Establish bio page template
- Add first group member bio
- Link new bio page to the Group members page