### PR TITLE
Add group publications

### DIFF
--- a/_includes/current_publications.html
+++ b/_includes/current_publications.html
@@ -21,7 +21,7 @@
     </p>
     <p>
         Green, S., Cooke, D. E. L., Dunn, M., Barwell, L., Purse, B., Chapman, D. S., 
-        Valatin, G., Schlenzig, A., Barbrook, J., Pettit, T., Price, C., P<&eacute>rez-Sierra, A., 
+        Valatin, G., Schlenzig, A., Barbrook, J., Pettit, T., Price, C., P&#xE9;rez-Sierra, A., 
         Frederickson-Matika, D., Pritchard, L., Thorpe, P., Cock, P. J., A., Randall, E., Keillor, 
         B., Marzano, M. (2021), <i>Forests</i>, Vol. 12, <a href="https://doi.org/10.3390/f12121617">https://doi.org/10.3390/f12121617</a>
     </p>

--- a/_includes/current_publications.html
+++ b/_includes/current_publications.html
@@ -1,16 +1,16 @@
 <!--The most recent publications from the group-->
 <div class=publicationsmall>
     <p>
-        Pritchard, L., Parul, S., Reza, M., Tessa, P., Luiz, I., Harrington, B., Heath, L., Brown, 
-        T. C., Vinatzer, B. (2022) 'genomeRxiv : a microbial whole-genome database and diagnostic 
-        marker design resource for classification, identification, and data sharing', 
+        Pritchard, L., Sharma, P., S., Mazloom, R., Piece, T., Irber, L., Harrington, B., Heath, L., Brown, T., Vinatzer, B. 
+        (2022) 'genomeRxiv: a microbial whole-genome database and diagnostic marker design resource for 
+        classification, identification, and data sharing', 
         <i>Microbiology Society Annual Conference 2021</i> 
         <a href="https://doi.org/10.1099/acmi.ac2021.po0165">https://doi.org/10.1099/acmi.ac2021.po0165</a>
     </p>
     <p>
         Pritchard, L. Brown, T., Harrington, B., Heath, L., Pierce-Ward, N. T., Vinatzer, B. A. 
         (2022) 'Could a focus on the "why" of taxonomy help taxonomy better respond to the needs 
-        of science and society?', <i>Fronteries in Microbiology</i>, Vol. 13, 
+        of science and society?', <i>Frontiers in Microbiology</i>, Vol. 13, 
         <a href="https://doi.org/10.3389/fmicb.2022.887310">https://doi.org/10.3389/fmicb.2022.887310</a>
     </p>
     <p>
@@ -29,7 +29,7 @@
         Hugouvieux-Cotte-Pattat, N., Jacot-des-Combes, C., Briolay, J., Pritchard, L. (2021) 
         'Proposal for the creation of a new genus Musicola gen. nov., reclassification of 
         Dickeya paradisiaca (Samson et al. 2005) as Musicola paradisiaca comb. nov. and 
-        description of a new species Musicola keenii sp. nov.', <i>International Journal of 
-            Systematic and EVol.utionary Microbiology</i>, Vol. 71, <a href="https://doi.org/10.1099/ijsem.0.005037">https://doi.org/10.1099/ijsem.0.005037</a>
+        description of a new species Musicola keenii sp. nov.', <i>International Journal of Systematic 
+            and Evolutionary Microbiology</i>, Vol. 71, <a href="https://doi.org/10.1099/ijsem.0.005037">https://doi.org/10.1099/ijsem.0.005037</a>
     </p>
 </div>

--- a/_includes/current_publications.html
+++ b/_includes/current_publications.html
@@ -1,6 +1,33 @@
 <!--The most recent publications from the group-->
 <div class=publicationsmall>
     <p>
+      Hobbs, E. E. M., Gloster, T. M., Pritchard, L. (2022) 'cazy_webscraper: local compilation and  
+      interrogation of comprehensive CAZyme datasets'. bioRxiv (PrePrint). 
+      <a href="https://www.biorxiv.org/content/10.1101/2022.12.02.518825v1">https://www.biorxiv.org/content/10.1101/2022.12.02.518825v1</a>
+    </p>
+    <p>
+      McLellan, H., Harvey, S. E., Steinbrenner, J., Armstrong, M. R., He, Q., Clewes, R., Pritchard, L.,  
+      Wang, W., Wang, S., Nussbaumer, T., Dohai, B., Luo, Q., Kumari, P., Duan, H., Roberts, A., Boevink,  
+      P. C., Neumann, C., Champouret, N., Hein, I., ... Birch, P. R. J. (2022). Exploiting breakdown in  
+      nonhost effector-target interactions to boost host disease resistance. Proceedings of the National  
+      Academy of Sciences of the United States of America, 119(35), [e2114064119].  
+      <a href="https://doi.org/10.1073/pnas.2114064119">https://doi.org/10.1073/pnas.2114064119</a>
+    </p>
+    <p>
+      Mazloom, R., Pritchard, L., Brown, C. T., Vinatzer, B. A., & Heath, L. S. (2022). LINgroups as a  
+      principled approach to compare and integrate multiple bacterial taxonomies. In Proceedings of  
+      the 13th ACM International Conference on Bioinformatics, Computational Biology and Health Informatics,  
+      BCB 2022: roceedings of the 13th ACM International Conference on Bioinformatics, Computational Biology  
+      and Health Informatics (pp. 1-7). [55] (Proceedings of the 13th ACM International Conference on  
+      Bioinformatics, Computational Biology and Health Informatics, BCB 2022). <a href="https://doi.org/10.1145/3535508.3545546">https://doi.org/10.1145/3535508.3545546</a>
+    </p>
+    <p>
+      Feeney, M. A., Newitt, J. T., Addington, E., Algora-Gallardo, L., Allan, C., Balis, L., Birke, A. S.,  
+      Castaño-Espriu, L., Charkoudian, L. K., Devine, R., _et al._ (2022). ActinoBase: tools and protocols  
+      for researchers working on Streptomyces and other filamentous actinobacteria. Microbial Genomics, 8(7),  
+      [000824]. <a href="https://doi.org/10.1099/mgen.0.000824">https://doi.org/10.1099/mgen.0.000824</a>
+    </p>
+    <p>
         Pritchard, L., Sharma, P., S., Mazloom, R., Piece, T., Irber, L., Harrington, B., Heath, L., Brown, T., Vinatzer, B. 
         (2022) 'genomeRxiv: a microbial whole-genome database and diagnostic marker design resource for 
         classification, identification, and data sharing', 
@@ -12,24 +39,5 @@
         (2022) 'Could a focus on the "why" of taxonomy help taxonomy better respond to the needs 
         of science and society?', <i>Frontiers in Microbiology</i>, Vol. 13, 
         <a href="https://doi.org/10.3389/fmicb.2022.887310">https://doi.org/10.3389/fmicb.2022.887310</a>
-    </p>
-    <p>
-        Kiepas, A., Hoskisson, P. A., Pritchard, L. (2022), 'Improved and extended multilocus 
-        sequence typing (MLST) scheme for Streptomyces reveals complex taxonomic structure', 
-        <i>Microbiology Society Annual Conference 2022</i>, pp. A148, 
-        <a href="https://doi.org/10.6084/m9.figshare.19615869.v1">https://doi.org/10.6084/m9.figshare.19615869.v1</a>
-    </p>
-    <p>
-        Green, S., Cooke, D. E. L., Dunn, M., Barwell, L., Purse, B., Chapman, D. S., 
-        Valatin, G., Schlenzig, A., Barbrook, J., Pettit, T., Price, C., P&#xE9;rez-Sierra, A., 
-        Frederickson-Matika, D., Pritchard, L., Thorpe, P., Cock, P. J., A., Randall, E., Keillor, 
-        B., Marzano, M. (2021), <i>Forests</i>, Vol. 12, <a href="https://doi.org/10.3390/f12121617">https://doi.org/10.3390/f12121617</a>
-    </p>
-    <p>
-        Hugouvieux-Cotte-Pattat, N., Jacot-des-Combes, C., Briolay, J., Pritchard, L. (2021) 
-        'Proposal for the creation of a new genus Musicola gen. nov., reclassification of 
-        Dickeya paradisiaca (Samson et al. 2005) as Musicola paradisiaca comb. nov. and 
-        description of a new species Musicola keenii sp. nov.', <i>International Journal of Systematic 
-            and Evolutionary Microbiology</i>, Vol. 71, <a href="https://doi.org/10.1099/ijsem.0.005037">https://doi.org/10.1099/ijsem.0.005037</a>
     </p>
 </div>

--- a/_includes/current_publications.html
+++ b/_includes/current_publications.html
@@ -1,0 +1,35 @@
+<!--The most recent publications from the group-->
+<div class=publicationsmall>
+    <p>
+        Pritchard, L., Parul, S., Reza, M., Tessa, P., Luiz, I., Harrington, B., Heath, L., Brown, 
+        T. C., Vinatzer, B. (2022) 'genomeRxiv : a microbial whole-genome database and diagnostic 
+        marker design resource for classification, identification, and data sharing', 
+        <i>Microbiology Society Annual Conference 2021</i> 
+        <a href="https://doi.org/10.1099/acmi.ac2021.po0165">https://doi.org/10.1099/acmi.ac2021.po0165</a>
+    </p>
+    <p>
+        Pritchard, L. Brown, T., Harrington, B., Heath, L., Pierce-Ward, N. T., Vinatzer, B. A. 
+        (2022) 'Could a focus on the "why" of taxonomy help taxonomy better respond to the needs 
+        of science and society?', <i>Fronteries in Microbiology</i>, Vol. 13, 
+        <a href="https://doi.org/10.3389/fmicb.2022.887310">https://doi.org/10.3389/fmicb.2022.887310</a>
+    </p>
+    <p>
+        Kiepas, A., Hoskisson, P. A., Pritchard, L. (2022), 'Improved and extended multilocus 
+        sequence typing (MLST) scheme for Streptomyces reveals complex taxonomic structure', 
+        <i>Microbiology Society Annual Conference 2022</i>, pp. A148, 
+        <a href="https://doi.org/10.6084/m9.figshare.19615869.v1">https://doi.org/10.6084/m9.figshare.19615869.v1</a>
+    </p>
+    <p>
+        Green, S., Cooke, D. E. L., Dunn, M., Barwell, L., Purse, B., Chapman, D. S., 
+        Valatin, G., Schlenzig, A., Barbrook, J., Pettit, T., Price, C., P<&eacute>rez-Sierra, A., 
+        Frederickson-Matika, D., Pritchard, L., Thorpe, P., Cock, P. J., A., Randall, E., Keillor, 
+        B., Marzano, M. (2021), <i>Forests</i>, Vol. 12, <a href="https://doi.org/10.3390/f12121617">https://doi.org/10.3390/f12121617</a>
+    </p>
+    <p>
+        Hugouvieux-Cotte-Pattat, N., Jacot-des-Combes, C., Briolay, J., Pritchard, L. (2021) 
+        'Proposal for the creation of a new genus Musicola gen. nov., reclassification of 
+        Dickeya paradisiaca (Samson et al. 2005) as Musicola paradisiaca comb. nov. and 
+        description of a new species Musicola keenii sp. nov.', <i>International Journal of 
+            Systematic and EVol.utionary Microbiology</i>, Vol. 71, <a href="https://doi.org/10.1099/ijsem.0.005037">https://doi.org/10.1099/ijsem.0.005037</a>
+    </p>
+</div>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -71,6 +71,10 @@ We are a computational biology research group in [SIPBS](https://www.strath.ac.u
 - synthetic biology
 - protein sequence-structure-function analysis
 
+## Latest Publications
+
+{% include current_publications.html %}
+
 ## Key Collaborators
 
 - SIPBS

--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -41,3 +41,4 @@
 
 /* SIPBS CompBiol-specific Filters */
 @import "sipbs-compbiol/filters";
+@import "sipbs-compbiol/publications";

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -39,6 +39,7 @@ $type-size-2: 1.953em !default; // ~31.248px
 $type-size-3: 1.563em !default; // ~25.008px
 $type-size-4: 1.25em !default; // ~20px
 $type-size-5: 1em !default; // ~16px
+$type-size-5-5: 0.875em !default; // ~14px
 $type-size-6: 0.75em !default; // ~12px
 $type-size-7: 0.6875em !default; // ~11px
 $type-size-8: 0.625em !default; // ~10px

--- a/_sass/sipbs-compbiol/_publications.scss
+++ b/_sass/sipbs-compbiol/_publications.scss
@@ -1,0 +1,39 @@
+/* indent with small text */
+
+.publicationsmall {
+    margin: 2em 1em 2em 0;
+    padding-left: 1em;
+    padding-right: 1em;
+    font-style: small;
+    font-size: $type-size-5-5;
+    border-left: 0.25em solid $primary-color;
+  
+    cite {
+      font-style: italic;
+  
+      &:before {
+        content: "\2014";
+        padding-right: 5px;
+      }
+    }
+  }
+
+  /* indent */
+
+.publications {
+    margin: 2em 1em 2em 0;
+    padding-left: 1em;
+    padding-right: 1em;
+    font-style: normal;
+    border-left: 0.25em solid $primary-color;
+  
+    cite {
+      font-style: italic;
+  
+      &:before {
+        content: "\2014";
+        padding-right: 5px;
+      }
+    }
+  }
+  


### PR DESCRIPTION
## Summary

Add list of the 5 most recent publications from the group to the home page

## Context

- The 5 most recent publications are stored in the file `_includes/current_publications.html`
- Add custom SCSS class for presenting the list of publications (`_sass/sipbs-compbiol/_publications.scss`)
    - Based upon `blockquote`
    - Text is not written in italics, as is the default for `<blockquote>`
    - Text is slightly smaller than the normal text (using the added custom font size `type-size-5-5` (~14px instead of ~16px for normal text) -- added to `_sass/minimal-mistakes/_variables.scss`)
